### PR TITLE
SqlDeveloper 23.x support (ojdbc8 -> ojdbc11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See https://www.spdba.com.au/georaptor-install/
 
 ### Manual installation ###
 
-1. Build project with Maven
+1. Build project with Maven and JDK 11+
 2. Create "sqldeveloper/GeoRaptor" folder.
 3. Copy ./target/GeoRaptor.zip to "sqldeveloper/GeoRaptor" folder.
 4. Start SQL Developer

--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,10 @@
 		</dependency>
 		<dependency>
 			<groupId>oracle</groupId>
-			<artifactId>ojdbc8</artifactId>
-			<version>12.2.0</version>
+			<artifactId>ojdbc11</artifactId>
+			<version>23.8.0.0.0</version>
 			<scope>system</scope>
-			<systemPath>${sqldev.basedir}/jdbc/lib/ojdbc8.jar</systemPath>
+			<systemPath>${sqldev.basedir}/jdbc/lib/ojdbc11.jar</systemPath>
 		</dependency>	
 		<dependency>
 			<groupId>oracle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>oracle</groupId>
 			<artifactId>ojdbc11</artifactId>
-			<version>23.8.0.0.0</version>
+			<version>21.8.0.0.0</version>
 			<scope>system</scope>
 			<systemPath>${sqldev.basedir}/jdbc/lib/ojdbc11.jar</systemPath>
 		</dependency>	


### PR DESCRIPTION
Directory "sqldeveloper/jdbc/lib/" newly contains "ojdbc11.jar" (since SqlDeveloper version 23)
=> updated pom.xml

It implies that it should be compiled with JDK 11+
=> README also updated.
